### PR TITLE
bug fix and a small improvement of cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,5 @@ add_definitions(${PCL_DEFINITIONS})
 
 add_executable(pclBundlerReader pointcloudscene.cpp camera.cpp main.cpp)
 target_link_libraries(pclBundlerReader ${PCL_LIBRARIES} boost_program_options)
+
+INSTALL_PROGRAMS(/bin FILES ${CMAKE_CURRENT_BINARY_DIR}/pclBundlerReader)

--- a/pointcloudscene.cpp
+++ b/pointcloudscene.cpp
@@ -22,7 +22,7 @@ void PointCloudScene::bundlerReader(const std::string& _fileName){
 
     std::cerr << "Reading Bundler file..." << std::endl;
 
-    std::ifstream inputFile(_fileName);
+    std::ifstream inputFile(_fileName.c_str());
     std::string line;
 
     int nPoints = 0;


### PR DESCRIPTION
1) Changed `ifstream(str)` to `ifstream(str.c_str())`. Initially it wouldn't compile for me.
2) Added INSTALL rule for cmake, so that the binary is given executable permissions and copied to the installation directory. User has to run `cmake install`
